### PR TITLE
waitFor takes a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,51 @@
 # ember-wait-for-test-helper
+
 [![npm version](https://badge.fury.io/js/ember-wait-for-test-helper.svg)](https://badge.fury.io/js/ember-wait-for-test-helper)
 
-Wait for css selectors to show up on screen. Useful for certain jquery plugins that take time to load. You can now avoid race conditions with a hard-coded wait time.
+Wait for your application to be in a specific state before continuing the test runner.
+
+Useful for certain jquery plugins that take time to load. You can now avoid race conditions with a hard-coded wait time.
 
 Add this line to `tests/helpers/start-app.js` in your app:
+
 ```js
 import 'ember-wait-for-test-helper/wait-for';
 ```
 
 Now you can do something like:
+
 ```js
-click('.button');
+import { selectorToExists } from 'ember-wait-for-test-helper/wait-for';
 
-waitFor('.a-slow-jquery-plugin');
+test("it should wait before asserting", function(assert) {
+  click('.button');
 
-andThen(() => {
-  assert.ok(find('.a-slow-jquery-plugin').length);
+  waitFor(selectorToExist('.a-slow-jquery-plugin'));
+
+  andThen(() => {
+    assert.ok(find('.a-slow-jquery-plugin').length === 1);
+  });
+});
+```
+
+### Custom waiters
+
+You can define your own waiters. A waiter is a function that will continuously
+run until it returns true. Once the waiter returns true your test will continue
+running.
+
+
+```js
+test("it should wait before asserting", function(assert) {
+  visit("/");
+
+  waitFor(() => {
+    let result = getAnswerFromSomewhere();
+    return result === 42; // only continue when result is 42
+  });
+
+  andThen(() => {
+    // ...
+  });
 });
 ```

--- a/addon/wait-for.js
+++ b/addon/wait-for.js
@@ -4,31 +4,25 @@ const {
   $,
   Test: {
     registerAsyncHelper,
-    _helpers: { find: { method: find } }
   },
   RSVP: { Promise }
 } = Ember;
 
-function _waitFor(
-  app,
-  selector,
-  context,
-  {
-    count = 1,
-    interval = 1
-  } = {}
-) {
-  let _find;
-  if (app) {
-    _find = find;
+function _waitFor(app, selectorOfFn, interval = 1) {
+  let waitForFn;
+
+  // Support old API where you can pass in a selector as
+  // a string and we'll wait for that to exist.
+  if (typeof selectorOfFn === "string") {
+    waitForFn = selectorToExist(selectorOfFn);
   } else {
-    _find = (app, selector, context) => $(selector, context);
+    waitForFn = selectorOfFn;
   }
 
   return new Promise(resolve => {
     (function restart() {
       setTimeout(() => {
-        if (_find(app, selector, context).length === count) {
+        if (waitForFn()) {
           resolve();
         } else {
           restart();
@@ -36,6 +30,17 @@ function _waitFor(
       }, interval);
     })();
   });
+}
+
+export function selectorToExist(selector, count) {
+  return function() {
+    let existsCount = $(selector).length;
+
+    if (count) {
+      return existsCount === count;
+    } else {
+      return existsCount > 0; }
+  };
 }
 
 export function waitFor(selector, context, options) {

--- a/addon/wait-for.js
+++ b/addon/wait-for.js
@@ -8,14 +8,40 @@ const {
   RSVP: { Promise }
 } = Ember;
 
-function _waitFor(app, selectorOrFn, interval = 1) {
+function _waitFor(app, selectorOrFn, contextOrOptions, selectorOptions) {
   let waitForFn;
+  let options;
+
+  // find the options argument
+  if (typeof contextOrOptions === "string") {
+    options = selectorOptions;
+  } else {
+    options = contextOrOptions;
+  }
+
+  // option defaults
+  options = options || {};
+  options.interval = options.interval || 1;
 
   // Support old API where you can pass in a selector as
-  // a string and we'll wait for that to exist.
+  // a string and we'll wait for that to exist. Can also
+  // pass along context and count option.
   if (typeof selectorOrFn === "string") {
-    waitForFn = selectorToExist(selectorOrFn);
+    let selector;
+    let count = options.count || 1;
+
+    // if context is a string we'll use it to scope the
+    // selector
+    if (typeof contextOrOptions === "string") {
+      let context = contextOrOptions;
+      selector = `${context} ${selectorOrFn}`;
+    } else {
+      selector = selectorOrFn;
+    }
+
+    waitForFn = selectorToExist(selector, count);
   } else {
+    // new style, selectorOrFn is a function
     waitForFn = selectorOrFn;
   }
 
@@ -27,7 +53,7 @@ function _waitFor(app, selectorOrFn, interval = 1) {
         } else {
           restart();
         }
-      }, interval);
+      }, options.interval);
     })();
   });
 }

--- a/addon/wait-for.js
+++ b/addon/wait-for.js
@@ -8,15 +8,15 @@ const {
   RSVP: { Promise }
 } = Ember;
 
-function _waitFor(app, selectorOfFn, interval = 1) {
+function _waitFor(app, selectorOrFn, interval = 1) {
   let waitForFn;
 
   // Support old API where you can pass in a selector as
   // a string and we'll wait for that to exist.
-  if (typeof selectorOfFn === "string") {
-    waitForFn = selectorToExist(selectorOfFn);
+  if (typeof selectorOrFn === "string") {
+    waitForFn = selectorToExist(selectorOrFn);
   } else {
-    waitForFn = selectorOfFn;
+    waitForFn = selectorOrFn;
   }
 
   return new Promise(resolve => {

--- a/addon/wait-for.js
+++ b/addon/wait-for.js
@@ -39,7 +39,8 @@ export function selectorToExist(selector, count) {
     if (count) {
       return existsCount === count;
     } else {
-      return existsCount > 0; }
+      return existsCount > 0;
+    }
   };
 }
 

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,8 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "waitFor"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/wait-for-test.js
+++ b/tests/acceptance/wait-for-test.js
@@ -1,0 +1,46 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+import { selectorToExist } from 'ember-wait-for-test-helper/wait-for';
+
+moduleForAcceptance('Acceptance | wait for');
+
+test('If given a string it should wait for a selector to exist', function(assert) {
+  visit("/");
+
+  click(".show-div");
+
+  waitFor(".div-exists");
+
+  andThen(() => {
+    assert.equal(find(".div-exists").length, 1);
+  });
+
+});
+
+test('If given a function it should wait for that function to return true', function(assert) {
+  let loops = 0;
+
+  visit("/");
+
+  waitFor(function() {
+    loops = loops + 1;
+    return loops === 100;
+  });
+
+  andThen(() => {
+    assert.equal(loops, 100);
+  });
+});
+
+test('Using the selectorToExist helper', function(assert) {
+  visit("/");
+
+  click(".show-div");
+
+  waitFor(selectorToExist(".div-exists"));
+
+  andThen(() => {
+    assert.equal(find(".div-exists").length, 1);
+  });
+});

--- a/tests/acceptance/wait-for-test.js
+++ b/tests/acceptance/wait-for-test.js
@@ -5,17 +5,43 @@ import { selectorToExist } from 'ember-wait-for-test-helper/wait-for';
 
 moduleForAcceptance('Acceptance | wait for');
 
+// support the old string based API
 test('If given a string it should wait for a selector to exist', function(assert) {
   visit("/");
 
-  click(".show-div");
+  click(".show1");
 
-  waitFor(".div-exists");
+  waitFor(".div1-exists");
 
   andThen(() => {
-    assert.equal(find(".div-exists").length, 1);
+    assert.equal(find(".div1-exists").length, 1);
   });
+});
 
+// support string based API w/ string context
+test('If given a string and a context, it should use the context into selectorToExist', function(assert) {
+  visit("/");
+
+  click(".show2");
+
+  waitFor(".div2-exists", ".div2-context");
+
+  andThen(() => {
+    assert.equal(find(".div2-exists", ".div2-context").length, 1);
+  });
+});
+
+// support string based API w/ options hash
+test('If given a string and options hash, it should pass the options to selectorToExist', function(assert) {
+  visit("/");
+
+  click(".show3");
+
+  waitFor(".div3-exists", { count: 2 });
+
+  andThen(() => {
+    assert.equal(find(".div3-exists").length, 2);
+  });
 });
 
 test('If given a function it should wait for that function to return true', function(assert) {
@@ -36,11 +62,11 @@ test('If given a function it should wait for that function to return true', func
 test('Using the selectorToExist helper', function(assert) {
   visit("/");
 
-  click(".show-div");
+  click(".show1");
 
-  waitFor(selectorToExist(".div-exists"));
+  waitFor(selectorToExist(".div1-exists"));
 
   andThen(() => {
-    assert.equal(find(".div-exists").length, 1);
+    assert.equal(find(".div1-exists").length, 1);
   });
 });

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  showDiv() {
-    this.set('isShowing', true);
-  },
+  isShowing1: false,
+  isShowing2: false,
+  isShowing3: false,
 
   actions: {
-    showDiv() {
+    show(n) {
       // normally we would use Ember.run.later for this. However,
       // Ember.Testing has a waiter that checks the run loop and will
       // wait for all queues to finish. In order to test waitFor we're
@@ -14,8 +14,9 @@ export default Ember.Controller.extend({
       // into this queue.
 
       setTimeout(() => {
-        console.log(this);
-        Ember.run(this, 'showDiv');
+        Ember.run(() => {
+          this.set(`isShowing${n}`, true);
+        });
       }, 2000);
     }
   }

--- a/tests/dummy/app/controllers/index.js
+++ b/tests/dummy/app/controllers/index.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  showDiv() {
+    this.set('isShowing', true);
+  },
+
+  actions: {
+    showDiv() {
+      // normally we would use Ember.run.later for this. However,
+      // Ember.Testing has a waiter that checks the run loop and will
+      // wait for all queues to finish. In order to test waitFor we're
+      // going to use setTimeout because Ember.Testing has no insight
+      // into this queue.
+
+      setTimeout(() => {
+        console.log(this);
+        Ember.run(this, 'showDiv');
+      }, 2000);
+    }
+  }
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,3 @@
-<h2 id="title">Welcome to Ember</h2>
+<h2 id="title">Welcome to waitFor</h2>
 
 {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,14 @@
+<p>
+  Clicking this button will cause a div to appear in
+  two seconds.
+</p>
+
+<button {{action "showDiv"}} class="show-div">Click me</button>
+
+{{#if isShowing}}
+
+  <div class="div-exists">
+    It exists!
+  </div>
+
+{{/if}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,11 +3,43 @@
   two seconds.
 </p>
 
-<button {{action "showDiv"}} class="show-div">Click me</button>
+{{! div 1 }}
 
-{{#if isShowing}}
+<button {{action "show" 1}} class="show1">Click me</button>
 
-  <div class="div-exists">
+{{#if isShowing1}}
+
+  <div class="div1-exists">
+    It exists!
+  </div>
+
+{{/if}}
+
+{{! div 2 }}
+
+<button {{action "show" 2}} class="show2">Click me</button>
+
+{{#if isShowing2}}
+
+  <div class="div2-context">
+    <div class="div2-exists">
+      It exists!
+    </div>
+  </div>
+
+{{/if}}
+
+
+{{! div 3 }}
+
+<button {{action "show" 3}} class="show3">Click me</button>
+
+{{#if isShowing3}}
+
+  <div class="div3-exists">
+    It exists!
+  </div>
+  <div class="div3-exists">
     It exists!
   </div>
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
+import 'ember-wait-for-test-helper/wait-for';
 
 export default function startApp(attrs) {
   let application;


### PR DESCRIPTION
`waitFor` now takes a function and waits for that function to return
true. If `waitFor` is passed a string it will wait for the selector to
exist.

I simplified the selector waitFor API. Let me know if this is going 
to cause problems in any of your apps.

I added some tests that use waitFor. They're pretty slow, but figured it's
ok since the suite is so small. If we start adding more cases I can speed
these up.

https://github.com/kellyselden/ember-wait-for-test-helper/issues/2