### PR TITLE
Cleanup waiters

### DIFF
--- a/addon/wait-for.js
+++ b/addon/wait-for.js
@@ -21,7 +21,7 @@ function _waitFor(app, selectorOrFn, contextOrOptions, selectorOptions) {
 
   // option defaults
   options = options || {};
-  options.interval = options.interval || 10;
+  options.interval = options.interval || 1;
 
   // Support old API where you can pass in a selector as
   // a string and we'll wait for that to exist. Can also

--- a/addon/wait-for.js
+++ b/addon/wait-for.js
@@ -71,7 +71,11 @@ function _waitFor(app, selectorOrFn, contextOrOptions, selectorOptions) {
   });
 }
 
-const _runningWaiters = new Map();
+// Normally we we use Map here, but that doesn't work
+// in phantom without including the babel polyfill.
+// Note that Ember.Map is private, so we may have
+// to refactor this out at some point.
+const _runningWaiters = new Ember.Map();
 
 function _track(label, timer) {
   _runningWaiters.set(label, timer);

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-wait-for-test-helper/index.js
+++ b/blueprints/ember-wait-for-test-helper/index.js
@@ -1,0 +1,33 @@
+/*jshint node:true*/
+
+var existsSync = require('exists-sync');
+
+module.exports = {
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  },
+
+  afterInstall: function() {
+    var addon = this;
+
+    if (existsSync('tests/helpers/destroy-app.js')) {
+      return addon.insertIntoFile(
+        'tests/helpers/destroy-app.js',
+        "import { cleanup } from 'ember-wait-for-test-helper/wait-for';",
+        {
+          after: "import Ember from 'ember';\n"
+        }
+      ).then(function() {
+        return addon.insertIntoFile(
+          'tests/helpers/destroy-app.js',
+          "  cleanup();",
+          {
+            before: "  Ember.run(application, 'destroy');"
+          });
+      });
+    }
+
+  }
+};

--- a/tests/acceptance/cleanup-test.js
+++ b/tests/acceptance/cleanup-test.js
@@ -6,9 +6,13 @@ import { selectorToExist, cleanup, activeCount } from 'ember-wait-for-test-helpe
 moduleForAcceptance('Acceptance | cleanup');
 
 test('I should be able to cancel waiters', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   visit('/');
+
+  // make sure that when this test starts there are 0 waiters running.
+  // The rest of the tests will be counting the total number of waiters.
+  assert.equal(activeCount(), 0);
 
   // this should cause our test to freeze until the runner
   // times out. at the point the suite will move on to the
@@ -20,7 +24,7 @@ test('I should be able to cancel waiters', function(assert) {
   // below should kick off.
   setTimeout(function() {
 
-    assert.ok(activeCount() === 1);
+    assert.equal(activeCount(), 1);
 
     cleanup();
 
@@ -30,6 +34,6 @@ test('I should be able to cancel waiters', function(assert) {
     // there should be no waiters running since we cleaned them
     // up. That means this andThen block should start running
     // once the cleanup compltes.
-    assert.ok(activeCount() === 0);
+    assert.equal(activeCount(), 0);
   });
 });

--- a/tests/acceptance/cleanup-test.js
+++ b/tests/acceptance/cleanup-test.js
@@ -1,0 +1,35 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+import { selectorToExist, cleanup, activeCount } from 'ember-wait-for-test-helper/wait-for';
+
+moduleForAcceptance('Acceptance | cleanup');
+
+test('I should be able to cancel waiters', function(assert) {
+  assert.expect(2);
+
+  visit('/');
+
+  // this should cause our test to freeze until the runner
+  // times out. at the point the suite will move on to the
+  // next test, so we want to make sure we cancel this timer.
+  waitFor(selectorToExist('.this-will-never-exist'));
+
+  // in order to test this will manually trigger a clear in a few
+  // seconds. at that point our waiter should stop and then andThen
+  // below should kick off.
+  setTimeout(function() {
+
+    assert.ok(activeCount() === 1);
+
+    cleanup();
+
+  }, 2000);
+
+  andThen(() => {
+    // there should be no waiters running since we cleaned them
+    // up. That means this andThen block should start running
+    // once the cleanup compltes.
+    assert.ok(activeCount() === 0);
+  });
+});

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
+import { cleanup } from 'ember-wait-for-test-helper/wait-for';
 
 export default function destroyApp(application) {
+  cleanup();
   Ember.run(application, 'destroy');
 }


### PR DESCRIPTION
I took a shot at cleaning up waiters after each acceptance test. This now tracks each waiter in a global map and cancels them in destroy-app.

Should address issue https://github.com/kellyselden/ember-wait-for-test-helper/issues/4

I modified the above issue's twiddle to demo this - https://ember-twiddle.com/a2636afd619bbe2d81160df0049ece6d?openFiles=tests.helpers.wait-for.js%2C